### PR TITLE
Add rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
I got a weird rust internal compiler error when I ran `cargo check` the first time, probably due to me using some nightly version. Adding this file makes sure `cargo` always uses the stable channel.